### PR TITLE
Add FindGoal to the BallPrediction struct

### DIFF
--- a/RedUtils/Objects/BallPrediction.cs
+++ b/RedUtils/Objects/BallPrediction.cs
@@ -48,5 +48,27 @@ namespace RedUtils
 
             return null;
         }
+        
+        /// <summary>Finds the first ball slice that is scoring in favor of the parameter team </summary>
+        public BallSlice FindGoal(int team)
+        {
+            int side = 1 - 2 * team;
+            if (Length > 0)
+            {
+                for (int i = 6; i < Length; i += 6)
+                {
+                    if (Slices[i].Location.y * side > 5250)
+                    {
+                        for (int j = i - 6; j < i; j++)
+                        {
+                            if (Slices[j].Location.y * side > 5250) 
+                                return Slices[j];
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
The Find cannot be used to find goals, since it breaks on the goals and returns null, and also returns null where there is no matches. Adding the FindGoal allows for this check.